### PR TITLE
Fix implicit groups used in search permission checks

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -4,7 +4,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_UTILS_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_UTILS_VERSION', '3.1.2' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_UTILS_VERSION', '3.1.3' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 ->register( 'utils', static function () {

--- a/src/ReadableNamespaces.php
+++ b/src/ReadableNamespaces.php
@@ -116,9 +116,10 @@ class ReadableNamespaces {
 	private function getUserGroups( UserIdentity $user ): array {
 		$groups = $this->userGroupCache[$user->getId()] ?? null;
 		if ( $groups === null ) {
-			$groups = $this->userGroupManager->getUserGroups( $user );
-			$groups[] = '*';
-			$groups[] = 'user';
+			$groups = array_merge(
+				$this->userGroupManager->getUserGroups( $user ),
+				$this->userGroupManager->getUserImplicitGroups( $user )
+			);
 			$this->userGroupCache[$user->getId()] = $groups;
 		}
 		return $groups;


### PR DESCRIPTION
As per doc of userGroupManager->getUserGroups():
"The implicit * and user groups are not included."

ERM47794